### PR TITLE
[WIP] Added link form as an option.

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -68,9 +68,12 @@ app.controller('talksController', ($scope, $http) => {
     // Send a http POST request to create a new talk
     $scope.createTalk = () => {
         if($scope.newTalk !== undefined) {
-            let {name, type, desc} = $scope.newTalk;
+            let {name, type, desc, link} = $scope.newTalk;
             
             if(name.trim() == '' || type.trim() == '' || desc.trim() == '') {
+                if (link.trim() == '') {
+                    link = '/'
+                }
                 alert('Empty fields. please try again');
                 $scope.newTalk = {};
                 return;

--- a/talks-ctrl.js
+++ b/talks-ctrl.js
@@ -42,14 +42,14 @@ module.exports.createTalk = (req, res) => {
 
 	// write the new talk to the server
 	return talksModel.sync().then(() => {
-		const { name, type, desc } = req.body;
+		const { name, type, desc, link } = req.body;
 		// create an instance of the model and save to the db
-		talksModel.create({name, type, desc}, {
-			fields: ['id', 'name', 'type', 'desc']
+		talksModel.create({name, type, desc, link}, {
+			fields: ['id', 'name', 'type', 'desc', 'link']
 		}).then(data => {
 			logger.log({
 				level: 'info',
-				message: `[CREATE] ${name} created a ${type} with the description: ${desc}`
+				message: `[CREATE] ${name} created a ${type} with the description: ${desc} link: ${link}`
 			});
 
 			// reload the talks
@@ -76,14 +76,14 @@ module.exports.updateTalk = (req, res) => {
 		);
 	}).then(() => {
 		return talksModel.find({
-			attributes: ['id', 'name', 'type', 'desc', 'hidden'],
+			attributes: ['id', 'name', 'type', 'desc', 'link', 'hidden'],
 			where: { id: req.body.talkId }
 		}).then(data => {
 			const talk = data.dataValues;
 
 			logger.log({
 				level: 'info',
-				message: `[UPDATE] The ${talk.type} "${talk.desc}" by ${talk.name} was ${talk.hidden ? 'hidden': 'unhidden'}`
+				message: `[UPDATE] The ${talk.type} "${talk.desc}" by ${talk.name} link: ${talk.link} was ${talk.hidden ? 'hidden': 'unhidden'}`
 			});
 
 			loadTalks(talksModel, res);
@@ -94,7 +94,7 @@ module.exports.updateTalk = (req, res) => {
 // Send a SELECT query to the database and return the response as JSON
 function loadTalks(model, res) {
 	return model.findAll({
-		attributes: ['id', 'name', 'type', 'desc', 'hidden']
+		attributes: ['id', 'name', 'type', 'desc', 'link', 'hidden']
 	}).then(result => {
 		return res.json(result);
 	});
@@ -102,7 +102,7 @@ function loadTalks(model, res) {
 
 function loadVisibleTalks(model, res) {
 	return model.findAll({
-		attributes: ['id', 'name', 'type', 'desc', 'hidden'],
+		attributes: ['id', 'name', 'type', 'desc', 'link', 'hidden'],
 		where: {hidden: false}
 	}).then(result => {
 		return res.json(result);

--- a/talks-model.js
+++ b/talks-model.js
@@ -8,6 +8,7 @@ module.exports = function(sequelize, DataTypes) {
       name: { type: DataTypes.STRING },
       type: { type: DataTypes.STRING },
       desc: { type: DataTypes.STRING },
+      link: { type: DataTypes.STRING },
       hidden: { type: DataTypes.BOOLEAN, defaultValue: false }
     },
     {

--- a/views/all.pug
+++ b/views/all.pug
@@ -29,11 +29,13 @@ html(ng-app='talksApp')
 				th Talk Presenter
 				th Type
 				th Description
+				th Link
 				th
 			tr(class="event" ng-class="{hidden: talk.hidden}" ng-repeat="talk in talks | filter: {type: 'forum topic'} | orderBy: ['type']")
 				td.name {{ talk.name }}
 				td.type {{ talk.type }}
 				td.desc {{ talk.desc }}
+				td.link: a(target='_blank' href='{{ talk.link }}') .
 				td.hides
 					button(ng-click="hide(this.talk.id)") X
 					button(ng-click="unhide(this.talk.id)") &#x21B6;
@@ -41,6 +43,7 @@ html(ng-app='talksApp')
 				td.name {{ talk.name }}
 				td.type {{ talk.type }}
 				td.desc {{ talk.desc }}
+				td.link: a(target='_blank' href='{{ talk.link }}') .
 				td.hides
 					button(ng-click="hide(this.talk.id)") X
 					button(ng-click="unhide(this.talk.id)") &#x21B6;
@@ -48,6 +51,7 @@ html(ng-app='talksApp')
 				td.name {{ talk.name }}
 				td.type {{ talk.type }}
 				td.desc {{ talk.desc }}
+				td.link: a(target='_blank' href='{{ talk.link }}') .
 				td.hides
 					button(ng-click="hide(this.talk.id)") X
 					button(ng-click="unhide(this.talk.id)") &#x21B6;
@@ -55,6 +59,7 @@ html(ng-app='talksApp')
 				td.name {{ talk.name }}
 				td.type {{ talk.type }}
 				td.desc {{ talk.desc }}
+				td.link: a(target='_blank' href='{{ talk.link }}') .
 				td.hides
 					button(ng-click="hide(this.talk.id)") X
 					button(ng-click="unhide(this.talk.id)") &#x21B6;
@@ -62,6 +67,7 @@ html(ng-app='talksApp')
 				td.name {{ talk.name }}
 				td.type {{ talk.type }}
 				td.desc {{ talk.desc }}
+				td.link: a(target='_blank' href='{{ talk.link }}') .
 				td.hides
 					button(ng-click="hide(this.talk.id)") X
 					button(ng-click="unhide(this.talk.id)") &#x21B6;
@@ -75,6 +81,7 @@ html(ng-app='talksApp')
 						option(value="announcement") Announcement
 						option(value="after meeting slot") After-Meeting Slot
 					th: input(id="in_desc" size=50 name="desc" type="text" ng-model="newTalk.desc" placeholder="Description" required)
+					th: input(id="in_link" size=30 name="link" type="text" ng-model="newTalk.link" placeholder="Link")
 					th: button(ng-click="createTalk()") Create
 
 		script(src="js/vendors/angular.min.js")

--- a/views/chrono.pug
+++ b/views/chrono.pug
@@ -29,11 +29,13 @@ html(ng-app='talksApp')
 				th Talk Presenter
 				th Type
 				th Description
+				th Link
 				th
 			tr(class="event" ng-class="{hidden: talk.hidden}" ng-repeat="talk in talks | filter: {'hidden': false} | orderBy: ['id']")
 				td.name {{ talk.name }}
 				td.type {{ talk.type }}
 				td.desc {{ talk.desc }}
+				td.link: a(target='_blank' href='{{ talk.link }}') .
 				td.hides
 					button(ng-click="hide(this.talk.id)") X
 					button(ng-click="unhide(this.talk.id)") &#x21B6;
@@ -47,6 +49,7 @@ html(ng-app='talksApp')
 						option(value="announcement") Announcement
 						option(value="after meeting slot") After-Meeting Slot
 					th: input(id="in_desc" size=50 name="desc" type="text" ng-model="newTalk.desc" placeholder="Description" required)
+					th: input(id="in_link" size=30 name="link" type="text" ng-model="newTalk.link" placeholder="Link")
 					th: button(ng-click="createTalk()") Create
 
 		script(src="js/vendors/angular.min.js")

--- a/views/index.pug
+++ b/views/index.pug
@@ -31,6 +31,7 @@ html(ng-app='talksApp')
 				th Talk Presenter
 				th Type
 				th Description
+				th Link
 				th
 
 			tbody
@@ -38,6 +39,7 @@ html(ng-app='talksApp')
 					td.name {{ talk.name }}
 					td.type {{ talk.type }}
 					td.desc {{ talk.desc }}
+					td.link: a(target='_blank' href='{{ talk.link }}') .
 					td.hides
 						button(ng-click="hide(this.talk.id)") X
 						button(ng-class="{'hidden-button': !talk.hidden}" ng-click="unhide(this.talk.id)") &#x21B6;
@@ -45,6 +47,7 @@ html(ng-app='talksApp')
 					td.name {{ talk.name }}
 					td.type {{ talk.type }}
 					td.desc {{ talk.desc }}
+					td.link: a(target='_blank' href='{{ talk.link }}') .
 					td.hides
 						button(ng-click="hide(this.talk.id)") X
 						button(ng-class="{'hidden-button': !talk.hidden}" ng-click="unhide(this.talk.id)") &#x21B6;
@@ -52,6 +55,7 @@ html(ng-app='talksApp')
 					td.name {{ talk.name }}
 					td.type {{ talk.type }}
 					td.desc {{ talk.desc }}
+					td.link: a(target='_blank' href='{{ talk.link }}') .
 					td.hides
 						button(ng-click="hide(this.talk.id)") X
 						button(ng-class="{'hidden-button': !talk.hidden}" ng-click="unhide(this.talk.id)") &#x21B6;
@@ -59,6 +63,7 @@ html(ng-app='talksApp')
 					td.name {{ talk.name }}
 					td.type {{ talk.type }}
 					td.desc {{ talk.desc }}
+					td.link: a(target='_blank' href='{{ talk.link }}') .
 					td.hides
 						button(ng-click="hide(this.talk.id)") X
 						button(ng-class="{'hidden-button': !talk.hidden}" ng-click="unhide(this.talk.id)") &#x21B6;
@@ -66,6 +71,7 @@ html(ng-app='talksApp')
 					td.name {{ talk.name }}
 					td.type {{ talk.type }}
 					td.desc {{ talk.desc }}
+					td.link: a(target='_blank' href='{{ talk.link }}') .
 					td.hides
 						button(ng-click="hide(this.talk.id)") X
 						button(ng-class="{'hidden-button': !talk.hidden}" ng-click="unhide(this.talk.id)") &#x21B6;
@@ -79,6 +85,7 @@ html(ng-app='talksApp')
 							option(value="announcement") Announcement
 							option(value="after meeting slot") After-Meeting Slot
 						th: input(id="in_desc" size=50 name="desc" type="text" ng-model="newTalk.desc" placeholder="Description")
+						th: input(id="in_link" size=30 name="link" type="text" ng-model="newTalk.link" placeholder="Link")
 						th: button(ng-click="createTalk()") Create
 
 		p(style="text-align: center;"): button(onclick="parseToMM()") Parse to Meeting Minutes


### PR DESCRIPTION
(Closes #26)
Users now have have the ability to add a link to their talk which will be rendered as a tino dot (should I accept another field for the name of the link?).
Before creating the talk:
![beforecreatetalk](https://user-images.githubusercontent.com/17727106/47687235-b3fbfe80-dbb5-11e8-90f1-d2b26e2b18f7.png)
With link field filled:
![link](https://user-images.githubusercontent.com/17727106/47687244-bfe7c080-dbb5-11e8-9380-7e48a487146b.png)
After talk is created:
![after create talk](https://user-images.githubusercontent.com/17727106/47687249-c70ece80-dbb5-11e8-8208-8fe961bfcf0f.png)
If the link field is left blank, it will default to talks.

