### PR TITLE
Add presenter names to meeting minutes per Andy's request.

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -169,7 +169,7 @@ function genCategory(talksList, title) {
     result += `# ${title}\n\n`;
 
     for (let topic of talksList) {
-        result += `## ${topic.desc}\n\n`;
+        result += `## ${topic.desc}\n\n${topic.name} - \n\n`;
     }
 
     return result;


### PR DESCRIPTION
Andy, who currently takes Meeting Minutes for the weekly meetings requested the functionality of having the presenter names be automatically added to the meeting minutes when generated. I've changed the format for that.